### PR TITLE
Use existing tracks with an id equal to CC# for captions

### DIFF
--- a/test/flash.test.js
+++ b/test/flash.test.js
@@ -1062,6 +1062,11 @@ QUnit.test('cleans up WebVTT cues on hls dispose', function() {
       addedTracks.push(trackEl.track);
       return trackEl;
     },
+    textTracks() {
+      return {
+        getTrackById() {}
+      };
+    },
     remoteTextTracks() {
       return addedTracks;
     },


### PR DESCRIPTION
This allows CC1 to work with text tracks provided by: https://github.com/videojs/videojs-contrib-hls/pull/1096